### PR TITLE
JWT認証のパース/usersテーブル・構造体Userのタグ修正/ユーザー関連のAPI作成 #3

### DIFF
--- a/db/migrations/20200426211110-create_users.sql
+++ b/db/migrations/20200426211110-create_users.sql
@@ -1,9 +1,9 @@
 
 -- +migrate Up
 CREATE TABLE IF NOT EXISTS users (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    id BIGINT PRIMARY KEY AUTO_INCREMENT UNSIGNED NOT NULL,
     name varchar(255),
-    email varchar(255) NOT NULL,
+    email varchar(255) NOT NULL unique,
     age int,
     gender int,
     image_url varchar(255),
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS users (
     password varchar(255) NOT NULL,
     created_at timestamp NOT NULL,
     updated_at timestamp NOT NULL,
-    deleted_at timestamp
+    deleted_at timestamp,
+    PRIMARY KEY (id)
 );
 -- +migrate Down
 DROP TABLE IF EXISTS users;

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/jinzhu/gorm v1.9.12
 	github.com/joho/godotenv v1.3.0
+	github.com/pkg/errors v0.8.1
 	github.com/rubenv/sql-migrate v0.0.0-20200423171638-eef9d3b68125 // indirect
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,7 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/main.go
+++ b/main.go
@@ -220,7 +220,21 @@ type UserHandler struct {
 //リクエストユーザーの情報を返す
 func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	headerAuthorization := r.Header.Get("Authorization")
+	if len(headerAuthorization) == 0 {
+		var error model.Error
+		error.Message = "認証トークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
 	bearerToken := strings.Split(headerAuthorization, " ")
+	if len(bearerToken) < 2 {
+		var error model.Error
+		error.Message = "bearerトークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusUnauthorized, error)
+		return
+	}
+
 	authToken := bearerToken[1]
 
 	parsedToken, err := Parse(authToken)

--- a/main.go
+++ b/main.go
@@ -97,9 +97,7 @@ func (f *SignUpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user.Password = string(hash)
 	password = string(hash)
 
-	db := f.DB
-
-	if err := db.Create(&model.User{Email: email, Password: password}).Error; err != nil {
+	if err := f.DB.Create(&model.User{Email: email, Password: password}).Error; err != nil {
 		var error model.Error
 		error.Message = "アカウントの作成に失敗しました"
 		errorInResponse(w, http.StatusUnauthorized, error)
@@ -157,11 +155,9 @@ func (f *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user.Email = email
 	user.Password = password
 
-	db := f.DB
-
 	var userData model.User
-	row := db.Where("email = ?", user.Email).Find(&userData)
-	if err := db.Where("email = ?", user.Email).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
+	row := f.DB.Where("email = ?", user.Email).Find(&userData)
+	if err := f.DB.Where("email = ?", user.Email).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
 		var error model.Error
 		error.Message = "該当するアカウントが見つかりません。"
 		errorInResponse(w, http.StatusUnauthorized, error)
@@ -247,11 +243,9 @@ func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userEmail := parsedToken.Email
 
-	db := f.DB
-
 	var user model.User
 
-	if err := db.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
+	if err := f.DB.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
 		error := model.Error{}
 		error.Message = "該当するアカウントが見つかりません。"
 		errorInResponse(w, http.StatusUnauthorized, error)
@@ -281,11 +275,9 @@ type AllUsersHandler struct {
 //全てのユーザーを返す
 func (f *AllUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	db := f.DB
-
 	allUsers := []model.User{}
 
-	if err := db.Find(&allUsers).Error; gorm.IsRecordNotFoundError(err) {
+	if err := f.DB.Find(&allUsers).Error; gorm.IsRecordNotFoundError(err) {
 		var error model.Error
 		error.Message = "該当するアカウントが見つかりません。"
 		errorInResponse(w, http.StatusInternalServerError, error)
@@ -338,11 +330,9 @@ func (f *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	favoriteArtist := d.FavoriteArtist
 	comment := d.Comment
 
-	db := f.DB
-
 	var user model.User
 
-	if err := db.Model(&user).Where("id = ?", id).Update(model.User{Email: email, Name: name, Age: age, Gender: gender, FavoriteMusicAge: favoriteMusicAge, FavoriteArtist: favoriteArtist, Comment: comment}).Error; err != nil {
+	if err := f.DB.Model(&user).Where("id = ?", id).Update(model.User{Email: email, Name: name, Age: age, Gender: gender, FavoriteMusicAge: favoriteMusicAge, FavoriteArtist: favoriteArtist, Comment: comment}).Error; err != nil {
 		var error model.Error
 		error.Message = "ユーザー情報の更新に失敗しました。"
 		errorInResponse(w, http.StatusInternalServerError, error)

--- a/main.go
+++ b/main.go
@@ -50,11 +50,11 @@ type Form struct {
 }
 
 type DB struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 type SignUpHandler struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 func (f *SignUpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +97,7 @@ func (f *SignUpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user.Password = string(hash)
 	password = string(hash)
 
-	db := f.Db
+	db := f.DB
 
 	if err := db.Create(&model.User{Email: email, Password: password}).Error; err != nil {
 		var error model.Error
@@ -126,7 +126,7 @@ func (f *SignUpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type LoginHandler struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 func (f *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -157,7 +157,7 @@ func (f *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user.Email = email
 	user.Password = password
 
-	db := f.Db
+	db := f.DB
 
 	var userData model.User
 	row := db.Where("email = ?", user.Email).Find(&userData)
@@ -214,7 +214,7 @@ func (f *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type UserHandler struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 //リクエストユーザーの情報を返す
@@ -247,7 +247,7 @@ func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	userEmail := parsedToken.Email
 
-	db := f.Db
+	db := f.DB
 
 	var user model.User
 
@@ -275,13 +275,13 @@ func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type AllUsersHandler struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 //全てのユーザーを返す
 func (f *AllUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	db := f.Db
+	db := f.DB
 
 	allUsers := []model.User{}
 
@@ -308,7 +308,7 @@ func (f *AllUsersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateUserHandler struct {
-	Db *gorm.DB
+	DB *gorm.DB
 }
 
 func (f *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -338,7 +338,7 @@ func (f *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	favoriteArtist := d.FavoriteArtist
 	comment := d.Comment
 
-	db := f.Db
+	db := f.DB
 
 	var user model.User
 
@@ -394,11 +394,11 @@ func main() {
 
 	r := mux.NewRouter()
 
-	r.Handle("/api/signup", &SignUpHandler{Db: db}).Methods("POST")
-	r.Handle("/api/login", &LoginHandler{Db: db}).Methods("POST")
-	r.Handle("/api/user", JwtMiddleware.Handler(&UserHandler{Db: db})).Methods("GET")
-	r.Handle("/api/users", JwtMiddleware.Handler(&AllUsersHandler{Db: db})).Methods("GET")
-	r.Handle("/api/user/{id}/update", JwtMiddleware.Handler(&UpdateUserHandler{Db: db})).Methods("PUT")
+	r.Handle("/api/signup", &SignUpHandler{DB: db}).Methods("POST")
+	r.Handle("/api/login", &LoginHandler{DB: db}).Methods("POST")
+	r.Handle("/api/user", JwtMiddleware.Handler(&UserHandler{DB: db})).Methods("GET")
+	r.Handle("/api/users", JwtMiddleware.Handler(&AllUsersHandler{DB: db})).Methods("GET")
+	r.Handle("/api/user/{id}/update", JwtMiddleware.Handler(&UpdateUserHandler{DB: db})).Methods("PUT")
 
 	if err := http.ListenAndServe(":8081", r); err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -121,7 +121,13 @@ func SignUpHandler(w http.ResponseWriter, r *http.Request) {
 		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
-	w.Write(v)
+
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "ユーザー情報の取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 }
 
 //type LoginHandler func(w http.ResponseWriter, r *http.Request) error
@@ -212,11 +218,11 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := w.Write(v2); err != nil {
-		log.Println(err)
+		var error model.Error
+		error.Message = "JWTトークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
 	}
-	//if err := http.ListenAndServe(":8081", r); err != nil {
-	//	log.Println(err)
-	//}
 }
 
 //リクエストユーザーの情報を返す
@@ -255,7 +261,12 @@ var UserHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	w.Write(v)
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "ユーザー情報の取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 })
 
 //全てのユーザーを返す
@@ -279,7 +290,12 @@ var AllUsersHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Reque
 		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
-	w.Write(v)
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "ユーザー一覧の取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 })
 
 var UpdateUserHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -322,17 +322,17 @@ func (f *UpdateUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	email := d.Email
-	name := d.Name
-	age := d.Age
-	gender := d.Gender
-	favoriteMusicAge := d.FavoriteMusicAge
-	favoriteArtist := d.FavoriteArtist
-	comment := d.Comment
+	//email := d.Email
+	//name := d.Name
+	//age := d.Age
+	//gender := d.Gender
+	//favoriteMusicAge := d.FavoriteMusicAge
+	//favoriteArtist := d.FavoriteArtist
+	//comment := d.Comment
 
 	var user model.User
 
-	if err := f.DB.Model(&user).Where("id = ?", id).Update(model.User{Email: email, Name: name, Age: age, Gender: gender, FavoriteMusicAge: favoriteMusicAge, FavoriteArtist: favoriteArtist, Comment: comment}).Error; err != nil {
+	if err := f.DB.Model(&user).Where("id = ?", id).Update(model.User{Email: d.Email, Name: d.Name, Age: d.Age, Gender: d.Gender, FavoriteMusicAge: d.FavoriteMusicAge, FavoriteArtist: d.FavoriteArtist, Comment: d.Comment}).Error; err != nil {
 		var error model.Error
 		error.Message = "ユーザー情報の更新に失敗しました。"
 		errorInResponse(w, http.StatusInternalServerError, error)

--- a/model/type.go
+++ b/model/type.go
@@ -25,3 +25,8 @@ type JWT struct {
 type Error struct {
 	Message string `json:"message"`
 }
+
+// Auth は署名前の認証トークン情報を表す。
+type Auth struct {
+	Email string
+}

--- a/model/type.go
+++ b/model/type.go
@@ -1,18 +1,21 @@
 package model
 
-import "github.com/jinzhu/gorm"
+import "time"
 
 type User struct {
-	gorm.Model
-	Name             string `json:"name"`
-	Email            string `json:"email,omitempty"`
-	Age              int    `json:"age,omitempty"`
-	Gender           int    `json:"gender,omitempty"`
-	ImageUrl         string `json:"imageUrl,omitempty"`
-	FavoriteMusicAge int    `json:"favoriteMusicAge,omitempty"`
-	FavoriteArtist   string `json:"favoriteArtist,omitempty"`
-	Comment          string `json:"comment,omitempty"`
-	Password         string `json:"-"`
+	ID               uint       `json:"id"`
+	CreatedAt        time.Time  `json:"createdAt"`
+	UpdatedAt        time.Time  `json:"updatedAt"`
+	DeletedAt        *time.Time `json:"deletedAt"`
+	Name             string     `json:"name"`
+	Email            string     `json:"email"`
+	Age              int        `json:"age"`
+	Gender           int        `json:"gender"`
+	ImageUrl         string     `json:"imageUrl"`
+	FavoriteMusicAge int        `json:"favoriteMusicAge"`
+	FavoriteArtist   string     `json:"favoriteArtist"`
+	Comment          string     `json:"comment"`
+	Password         string     `json:"-"`
 }
 
 type JWT struct {

--- a/model/type.go
+++ b/model/type.go
@@ -12,7 +12,7 @@ type User struct {
 	FavoriteMusicAge int    `json:"favoriteMusicAge,omitempty"`
 	FavoriteArtist   string `json:"favoriteArtist,omitempty"`
 	Comment          string `json:"comment,omitempty"`
-	Password         string `json:"password"`
+	Password         string `json:"-"`
 }
 
 type JWT struct {

--- a/model/type.go
+++ b/model/type.go
@@ -8,7 +8,7 @@ type User struct {
 	Email            string `json:"email,omitempty"`
 	Age              int    `json:"age,omitempty"`
 	Gender           int    `json:"gender,omitempty"`
-	ImageUrl         string `json:"age,omitempty"`
+	ImageUrl         string `json:"imageUrl,omitempty"`
 	FavoriteMusicAge int    `json:"favoriteMusicAge,omitempty"`
 	FavoriteArtist   string `json:"favoriteArtist,omitempty"`
 	Comment          string `json:"comment,omitempty"`


### PR DESCRIPTION
- JWT認証トークンのパース処理追加

- usersテーブルについて、idにunsigned追加・emailにunique追加

- リクエストユーザーの情報を返すAPI作成
ヘッダーに入っているJWTトークンをパースしてEmailを取得し、そこからユーザーの情報を取得

- 全てのユーザーの情報を返すAPI作成

- ユーザーの情報を更新するAPI作成

- 構造体Userの修正
1. gorm.modelを使わないように変更。（タグを設定したかったため）
2.タグにて不要なomitemptyを削除
3. Passwordフィールドにてタグ-を設定して、jsonで返さないように変更。