### PR TITLE
SpotifyAPIを用いた曲検索機能 / 曲のCRUDのAPI作成 / データベースに曲情報のテーブル作成  #5

### DIFF
--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -7,9 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/konojunya/musi/service"
-
-	"github.com/jinzhu/gorm"
+	"golang-songs/service"
 
 	"github.com/joho/godotenv"
 	"golang.org/x/oauth2"
@@ -17,81 +15,19 @@ import (
 
 var config oauth2.Config
 
-type Code struct {
-	Code string
+// レスポンスにエラーを突っ込んで、返却するメソッド
+func errorInResponse(w http.ResponseWriter, status int, error model.Error) {
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(error)
+	return
 }
 
-type Title struct {
-	Title string
-	Token string
-}
-
-//var OAuth = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//	//func OAuth(c *gin.Context) {
-//
-//	//codeにClient IDとClient SecretをBase64でエンコードした値を入れる
-//	dec := json.NewDecoder(r.Body)
-//	var d Code
-//	if err := dec.Decode(&d); err != nil {
-//		var error model.Error
-//		error.Message = "リクエストボディのデコードに失敗しました。"
-//		errorInResponse(w, http.StatusInternalServerError, error)
-//		return
-//	}
-//
-//	code := d.Code
-//
-//	err := godotenv.Load()
-//	if err != nil {
-//		var error model.Error
-//		error.Message = ".envファイルの読み込み失敗"
-//		errorInResponse(w, http.StatusUnauthorized, error)
-//		return
-//	}
-//
-//	config = oauth2.Config{
-//		ClientID:     os.Getenv("client_id"),
-//		ClientSecret: os.Getenv("client_secret"),
-//		Endpoint: oauth2.Endpoint{
-//			AuthURL:  "https://accounts.spotify.com/authorize",
-//			TokenURL: "https://accounts.spotify.com/api/token",
-//		},
-//		RedirectURL: "http://localhost:3000/spotify/songs",
-//		Scopes:      []string{},
-//	}
-//
-//	//認証のURL
-//	//GetRedirectURL()の中でしたい
-//	url := config.AuthCodeURL("test")
-//
-//	token, err := config.Exchange(oauth2.NoContext, code)
-//
-//	if err != nil {
-//		log.Println(err)
-//	}
-//})
-
-type GetToken struct {
-	DB *gorm.DB
-}
-
-func (f *GetToken) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	dec := json.NewDecoder(r.Body)
-	var d Code
-	if err := dec.Decode(&d); err != nil {
-		var error model.Error
-		error.Message = "リクエストボディのデコードに失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
-	code := d.Code
-
+func GetRedirectURL(w http.ResponseWriter, r *http.Request) {
 	err := godotenv.Load()
 	if err != nil {
 		var error model.Error
 		error.Message = ".envの読み込みに失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 
@@ -99,57 +35,8 @@ func (f *GetToken) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ClientID:     os.Getenv("client_id"),
 		ClientSecret: os.Getenv("client_secret"),
 		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://accounts.spotify.com/authorize",
 			TokenURL: "https://accounts.spotify.com/api/token",
-		},
-		RedirectURL: "http://localhost:3000/spotify/songs",
-		Scopes:      []string{},
-	}
-
-	token, err := config.Exchange(oauth2.NoContext, code)
-	if err != nil {
-		var error model.Error
-		error.Message = "トークンの取得に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-
-	v, err := json.Marshal(token.AccessToken)
-	if err != nil {
-		var error model.Error
-		error.Message = "JSONへの変換に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
-	if _, err := w.Write(v); err != nil {
-		var error model.Error
-		error.Message = "URLの取得に失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-}
-
-type GetRedirectURL struct {
-	DB *gorm.DB
-}
-
-func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	err := godotenv.Load()
-	if err != nil {
-		var error model.Error
-		error.Message = ".envの読み込みに失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
-	config = oauth2.Config{
-		ClientID:     os.Getenv("client_id"),
-		ClientSecret: os.Getenv("client_secret"),
-		Endpoint: oauth2.Endpoint{
-			AuthURL: "https://accounts.spotify.com/authorize",
-			//TokenURL: "https://accounts.spotify.com/api/token",
 		},
 
 		RedirectURL: "http://localhost:3000/spotify/songs",
@@ -163,7 +50,7 @@ func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, err := json.Marshal(url); err != nil {
 		var error model.Error
 		error.Message = "JSONへの変換に失敗しました。"
-		//errorInResponse(w, http.StatusUnauthorized, error)
+		errorInResponse(w, http.StatusUnauthorized, error)
 		return
 	}
 
@@ -171,14 +58,68 @@ func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var error model.Error
 		error.Message = "JSONへの変換に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 
 	if _, err := w.Write(v); err != nil {
 		var error model.Error
 		error.Message = "URLの取得に失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+}
+
+func GetToken(w http.ResponseWriter, r *http.Request) {
+	dec := json.NewDecoder(r.Body)
+	var d model.Code
+	if err := dec.Decode(&d); err != nil {
+		var error model.Error
+		error.Message = "リクエストボディのデコードに失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	err := godotenv.Load()
+	if err != nil {
+		var error model.Error
+		error.Message = ".envの読み込みに失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	config = oauth2.Config{
+		ClientID:     os.Getenv("client_id"),
+		ClientSecret: os.Getenv("client_secret"),
+		Endpoint: oauth2.Endpoint{
+			TokenURL: "https://accounts.spotify.com/api/token",
+		},
+		RedirectURL: "http://localhost:3000/spotify/songs",
+		Scopes:      []string{},
+	}
+
+	token, err := config.Exchange(oauth2.NoContext, d.Code)
+	if err != nil {
+		var error model.Error
+		error.Message = "トークンの取得に失敗しました"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	v, err := json.Marshal(token.AccessToken)
+	if err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "URLの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 }
@@ -186,10 +127,7 @@ func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func JSONSafeMarshal(v interface{}, safeEncoding bool) ([]byte, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
-		var error model.Error
-		error.Message = "JSONへの変換に失敗しました。"
-		//errorInResponse(w, http.StatusUnauthorized, error)
-		//return
+		return nil, err
 	}
 
 	if safeEncoding {
@@ -200,40 +138,29 @@ func JSONSafeMarshal(v interface{}, safeEncoding bool) ([]byte, error) {
 	return b, err
 }
 
-type GetTracks struct {
-	DB *gorm.DB
-}
-
-func (f *GetTracks) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	//var GetTracks = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	//一旦は直打ち OAuthで帰ってきたtoken: &{BQChNb6GK...の最初の部分
-	//cookie := "AQBuZP2SIhzr3mTQrjKceOoK60cOGSHlVCpWRPH6pS_n13c8st-Oq18qcUuBMvuhKMKgtcKSxE4i01Vytt3M7y_78nTQqVcvpmzU1MjSJLSMrfLeF3p3yvxoYIe9Uf5PctWkjetxWD5WT11NptJ9ksmxo4AmuzIcRWN3IjyDiYnaBA7665016xVUlkQJFhHlKfXvpXSn3gCvJ_0"
+func GetTracks(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
-	var d Title
+	var d model.SearchTitle
 	if err := dec.Decode(&d); err != nil {
 		var error model.Error
 		error.Message = "リクエストボディのデコードに失敗しました。"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 
-	cookie := d.Token
-	title := d.Title
-
-	if cookie == "" {
+	if d.Token == "" {
 		var error model.Error
 		error.Message = "アクセストークンの取得に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 
 	//トラック（曲）検索
-	//tracks, err := service.GetTracks(cookie)
-	tracks, err := service.GetTracks(cookie, title)
+	tracks, err := service.GetTracks(d.Token, d.Title)
 	if err != nil {
 		var error model.Error
 		error.Message = "トラックの取得に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
 
@@ -243,8 +170,14 @@ func (f *GetTracks) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var error model.Error
 		error.Message = "JSONへの変換に失敗しました"
-		//errorInResponse(w, http.StatusInternalServerError, error)
+		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
-	w.Write(v)
+
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "トラックの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 }

--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -19,8 +19,12 @@ var config oauth2.Config
 // レスポンスにエラーを突っ込んで、返却するメソッド
 func errorInResponse(w http.ResponseWriter, status int, error model.Error) {
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(error)
-	return
+	if err := json.NewEncoder(w).Encode(error); err != nil {
+		var error model.Error
+		error.Message = "リクエストボディのデコードに失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 }
 
 func GetRedirectURL(w http.ResponseWriter, r *http.Request) {

--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"golang-songs/model"
@@ -114,20 +113,6 @@ func GetToken(w http.ResponseWriter, r *http.Request) {
 		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
-}
-
-func JSONSafeMarshal(v interface{}, safeEncoding bool) ([]byte, error) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-
-	if safeEncoding {
-		b = bytes.Replace(b, []byte("\\u003c"), []byte("<"), -1)
-		b = bytes.Replace(b, []byte("\\u003e"), []byte(">"), -1)
-		b = bytes.Replace(b, []byte("\\u0026"), []byte("&"), -1)
-	}
-	return b, err
 }
 
 func GetTracks(w http.ResponseWriter, r *http.Request) {

--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var config oauth2.Config
-
 // レスポンスにエラーを突っ込んで、返却するメソッド
 func errorInResponse(w http.ResponseWriter, status int, error model.Error) {
 	w.WriteHeader(status)
@@ -36,7 +34,7 @@ func GetRedirectURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config = oauth2.Config{
+	config := oauth2.Config{
 		ClientID:     os.Getenv("client_id"),
 		ClientSecret: os.Getenv("client_secret"),
 		Endpoint: oauth2.Endpoint{
@@ -52,24 +50,13 @@ func GetRedirectURL(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if _, err := json.Marshal(url); err != nil {
+	// Encodeを用いたJson変換
+	encoder := json.NewEncoder(w)
+	//自動エスケープを無効に
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(url); err != nil {
 		var error model.Error
 		error.Message = "JSONへの変換に失敗しました。"
-		errorInResponse(w, http.StatusUnauthorized, error)
-		return
-	}
-
-	v, err := JSONSafeMarshal(url, true)
-	if err != nil {
-		var error model.Error
-		error.Message = "JSONへの変換に失敗しました"
-		errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
-	if _, err := w.Write(v); err != nil {
-		var error model.Error
-		error.Message = "URLの取得に失敗しました。"
 		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
@@ -93,7 +80,7 @@ func GetToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	config = oauth2.Config{
+	config := oauth2.Config{
 		ClientID:     os.Getenv("client_id"),
 		ClientSecret: os.Getenv("client_secret"),
 		Endpoint: oauth2.Endpoint{

--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"golang-songs/model"
 	"net/http"
@@ -98,7 +99,7 @@ func GetToken(w http.ResponseWriter, r *http.Request) {
 		Scopes:      []string{},
 	}
 
-	token, err := config.Exchange(oauth2.NoContext, d.Code)
+	token, err := config.Exchange(context.TODO(), d.Code)
 	if err != nil {
 		var error model.Error
 		error.Message = "トークンの取得に失敗しました"

--- a/controller/spotify.go
+++ b/controller/spotify.go
@@ -1,0 +1,250 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"golang-songs/model"
+	"net/http"
+	"os"
+
+	"github.com/konojunya/musi/service"
+
+	"github.com/jinzhu/gorm"
+
+	"github.com/joho/godotenv"
+	"golang.org/x/oauth2"
+)
+
+var config oauth2.Config
+
+type Code struct {
+	Code string
+}
+
+type Title struct {
+	Title string
+	Token string
+}
+
+//var OAuth = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//	//func OAuth(c *gin.Context) {
+//
+//	//codeにClient IDとClient SecretをBase64でエンコードした値を入れる
+//	dec := json.NewDecoder(r.Body)
+//	var d Code
+//	if err := dec.Decode(&d); err != nil {
+//		var error model.Error
+//		error.Message = "リクエストボディのデコードに失敗しました。"
+//		errorInResponse(w, http.StatusInternalServerError, error)
+//		return
+//	}
+//
+//	code := d.Code
+//
+//	err := godotenv.Load()
+//	if err != nil {
+//		var error model.Error
+//		error.Message = ".envファイルの読み込み失敗"
+//		errorInResponse(w, http.StatusUnauthorized, error)
+//		return
+//	}
+//
+//	config = oauth2.Config{
+//		ClientID:     os.Getenv("client_id"),
+//		ClientSecret: os.Getenv("client_secret"),
+//		Endpoint: oauth2.Endpoint{
+//			AuthURL:  "https://accounts.spotify.com/authorize",
+//			TokenURL: "https://accounts.spotify.com/api/token",
+//		},
+//		RedirectURL: "http://localhost:3000/spotify/songs",
+//		Scopes:      []string{},
+//	}
+//
+//	//認証のURL
+//	//GetRedirectURL()の中でしたい
+//	url := config.AuthCodeURL("test")
+//
+//	token, err := config.Exchange(oauth2.NoContext, code)
+//
+//	if err != nil {
+//		log.Println(err)
+//	}
+//})
+
+type GetToken struct {
+	DB *gorm.DB
+}
+
+func (f *GetToken) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	dec := json.NewDecoder(r.Body)
+	var d Code
+	if err := dec.Decode(&d); err != nil {
+		var error model.Error
+		error.Message = "リクエストボディのデコードに失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	code := d.Code
+
+	err := godotenv.Load()
+	if err != nil {
+		var error model.Error
+		error.Message = ".envの読み込みに失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	config = oauth2.Config{
+		ClientID:     os.Getenv("client_id"),
+		ClientSecret: os.Getenv("client_secret"),
+		Endpoint: oauth2.Endpoint{
+			TokenURL: "https://accounts.spotify.com/api/token",
+		},
+		RedirectURL: "http://localhost:3000/spotify/songs",
+		Scopes:      []string{},
+	}
+
+	token, err := config.Exchange(oauth2.NoContext, code)
+	if err != nil {
+		var error model.Error
+		error.Message = "トークンの取得に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	v, err := json.Marshal(token.AccessToken)
+	if err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "URLの取得に失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+}
+
+type GetRedirectURL struct {
+	DB *gorm.DB
+}
+
+func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := godotenv.Load()
+	if err != nil {
+		var error model.Error
+		error.Message = ".envの読み込みに失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	config = oauth2.Config{
+		ClientID:     os.Getenv("client_id"),
+		ClientSecret: os.Getenv("client_secret"),
+		Endpoint: oauth2.Endpoint{
+			AuthURL: "https://accounts.spotify.com/authorize",
+			//TokenURL: "https://accounts.spotify.com/api/token",
+		},
+
+		RedirectURL: "http://localhost:3000/spotify/songs",
+		Scopes:      []string{},
+	}
+
+	url := config.AuthCodeURL("state")
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if _, err := json.Marshal(url); err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました。"
+		//errorInResponse(w, http.StatusUnauthorized, error)
+		return
+	}
+
+	v, err := JSONSafeMarshal(url, true)
+	if err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	if _, err := w.Write(v); err != nil {
+		var error model.Error
+		error.Message = "URLの取得に失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+}
+
+func JSONSafeMarshal(v interface{}, safeEncoding bool) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました。"
+		//errorInResponse(w, http.StatusUnauthorized, error)
+		//return
+	}
+
+	if safeEncoding {
+		b = bytes.Replace(b, []byte("\\u003c"), []byte("<"), -1)
+		b = bytes.Replace(b, []byte("\\u003e"), []byte(">"), -1)
+		b = bytes.Replace(b, []byte("\\u0026"), []byte("&"), -1)
+	}
+	return b, err
+}
+
+type GetTracks struct {
+	DB *gorm.DB
+}
+
+func (f *GetTracks) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	//var GetTracks = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//一旦は直打ち OAuthで帰ってきたtoken: &{BQChNb6GK...の最初の部分
+	//cookie := "AQBuZP2SIhzr3mTQrjKceOoK60cOGSHlVCpWRPH6pS_n13c8st-Oq18qcUuBMvuhKMKgtcKSxE4i01Vytt3M7y_78nTQqVcvpmzU1MjSJLSMrfLeF3p3yvxoYIe9Uf5PctWkjetxWD5WT11NptJ9ksmxo4AmuzIcRWN3IjyDiYnaBA7665016xVUlkQJFhHlKfXvpXSn3gCvJ_0"
+	dec := json.NewDecoder(r.Body)
+	var d Title
+	if err := dec.Decode(&d); err != nil {
+		var error model.Error
+		error.Message = "リクエストボディのデコードに失敗しました。"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	cookie := d.Token
+	title := d.Title
+
+	if cookie == "" {
+		var error model.Error
+		error.Message = "アクセストークンの取得に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	//トラック（曲）検索
+	//tracks, err := service.GetTracks(cookie)
+	tracks, err := service.GetTracks(cookie, title)
+	if err != nil {
+		var error model.Error
+		error.Message = "トラックの取得に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	v, err := json.Marshal(tracks)
+	if err != nil {
+		var error model.Error
+		error.Message = "JSONへの変換に失敗しました"
+		//errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+	w.Write(v)
+}

--- a/db/migrations/20200509191613-create_songs.sql
+++ b/db/migrations/20200509191613-create_songs.sql
@@ -1,0 +1,22 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS songs (
+    id BIGINT AUTO_INCREMENT NOT NULL,
+    title varchar(255) NOT NULL,
+    artist varchar(255) NOT NULL,
+    music_age int NOT NULL,
+    image varchar(255),
+    video varchar(255),
+    album varchar(255),
+    description varchar(255),
+    spotify_track_id varchar(255),
+    user_id BIGINT NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
+    deleted_at timestamp,
+    PRIMARY KEY (id),
+    FOREIGN KEY(user_id)
+    REFERENCES users(id)
+);
+-- +migrate Down
+DROP TABLE IF EXISTS songs;

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/jinzhu/gorm v1.9.12
 	github.com/joho/godotenv v1.3.0
+	github.com/konojunya/musi v0.0.0-20180914070733-7b07028f5f7b
 	github.com/pkg/errors v0.8.1
 	github.com/rubenv/sql-migrate v0.0.0-20200423171638-eef9d3b68125 // indirect
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/briandowns/openweathermap v0.0.0-20180804155945-5f41b7c9d92d h1:28xWzPQ9bdGxKAAwQpZipZZ9Xz8kQcgMPF9cZnvMeuI=
+github.com/briandowns/openweathermap v0.0.0-20180804155945-5f41b7c9d92d/go.mod h1:8g1Bgq9PbPpXIA3sdlWmWf2JpiWGJee/O4Q+ddYO6+k=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -68,8 +70,10 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
+github.com/gin-gonic/gin v1.3.0/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6mUr7Y=
 github.com/gin-gonic/gin v1.6.2 h1:88crIK23zO6TqlQBt+f9FrPJNKm9ZEr7qjp9vl/d5TM=
 github.com/gin-gonic/gin v1.6.2/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -176,6 +180,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konojunya/musi v0.0.0-20180914070733-7b07028f5f7b h1:7uhUI0LH2VhCBzsYRo729s/R77OPnGCkzq6PuBVSDow=
+github.com/konojunya/musi v0.0.0-20180914070733-7b07028f5f7b/go.mod h1:vAqlkVJKjwm2Cwmbm5BIvo+3voVJCyMPlRk68baEQlc=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -317,6 +323,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v0.0.0-20180831062425-e253f1f20942/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
@@ -364,6 +371,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -379,6 +387,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -463,6 +472,7 @@ gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/gorp.v1 v1.7.2 h1:j3DWlAyGVv8whO7AcIWznQ2Yj7yJkn34B8s63GViAAw=
 gopkg.in/gorp.v1 v1.7.2/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"golang-songs/controller"
 	"golang-songs/model"
 	"log"
 	"net/http"
@@ -403,6 +404,50 @@ func (f *CreateSongHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//type GetRedirectURL struct {
+//	DB *gorm.DB
+//}
+//
+//func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//	//var GetRedirectURL = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//	err := godotenv.Load()
+//	if err != nil {
+//		log.Println(".envファイルの読み込み失敗")
+//	}
+//
+//	//func GetRedirectURL() string {
+//	config = oauth2.Config{
+//		ClientID:     os.Getenv("client_id"),
+//		ClientSecret: os.Getenv("client_secret"),
+//		Endpoint: oauth2.Endpoint{
+//			AuthURL:  "https://accounts.spotify.com/authorize",
+//			TokenURL: "https://accounts.spotify.com/api/token",
+//		},
+//
+//		RedirectURL: "http://localhost:3000/spotify/songs",
+//		Scopes:      []string{},
+//	}
+//
+//	url := config.AuthCodeURL("state")
+//	log.Println(url)
+//
+//	w.Header().Set("Content-Type", "application/json")
+//
+//	v, err := json.Marshal(url)
+//	if err != nil {
+//		fmt.Println(err)
+//	}
+//	log.Println(v)
+//	b, err := JSONSafeMarshal(url, true)
+//	if err != nil {
+//		//c.AbortWithStatus(http.StatusInternalServerError)
+//		//return
+//		log.Println("Marshal取得失敗")
+//	}
+//	//log.Println(v)
+//	w.Write(b)
+//}
+
 func main() {
 	err := godotenv.Load()
 	if err != nil {
@@ -427,7 +472,12 @@ func main() {
 	r.Handle("/api/users", JwtMiddleware.Handler(&AllUsersHandler{DB: db})).Methods("GET")
 	r.Handle("/api/user/{id}/update", JwtMiddleware.Handler(&UpdateUserHandler{DB: db})).Methods("PUT")
 
-	r.Handle("/api/users", JwtMiddleware.Handler(&CreateSongHandler{DB: db})).Methods("GET")
+	r.Handle("/api/song", JwtMiddleware.Handler(&CreateSongHandler{DB: db})).Methods("POST")
+
+	r.Handle("/api/getRedirectUrl", JwtMiddleware.Handler(&controller.GetRedirectURL{DB: db})).Methods("GET")
+	r.Handle("/api/getToken", JwtMiddleware.Handler(&controller.GetToken{DB: db})).Methods("POST")
+	r.Handle("/api/tracks", JwtMiddleware.Handler(&controller.GetTracks{DB: db})).Methods("POST")
+	//r.HandleFunc("/api/tracks", controller.GetTracks).Methods("POST")
 
 	if err := http.ListenAndServe(":8081", r); err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -30,11 +30,6 @@ func errorInResponse(w http.ResponseWriter, status int, error model.Error) {
 	return
 }
 
-type Form struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
-}
-
 type SignUpHandler struct {
 	DB *gorm.DB
 }
@@ -43,7 +38,7 @@ func (f *SignUpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var user model.User
 
 	dec := json.NewDecoder(r.Body)
-	var d Form
+	var d model.Form
 	if err := dec.Decode(&d); err != nil {
 		var error model.Error
 		error.Message = "リクエストボディのデコードに失敗しました。"
@@ -120,7 +115,7 @@ func (f *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var jwt model.JWT
 
 	dec := json.NewDecoder(r.Body)
-	var d Form
+	var d model.Form
 	if err := dec.Decode(&d); err != nil {
 		var error model.Error
 		error.Message = "リクエストボディのデコードに失敗しました。"
@@ -404,50 +399,6 @@ func (f *CreateSongHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//type GetRedirectURL struct {
-//	DB *gorm.DB
-//}
-//
-//func (f *GetRedirectURL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-//	//var GetRedirectURL = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//	err := godotenv.Load()
-//	if err != nil {
-//		log.Println(".envファイルの読み込み失敗")
-//	}
-//
-//	//func GetRedirectURL() string {
-//	config = oauth2.Config{
-//		ClientID:     os.Getenv("client_id"),
-//		ClientSecret: os.Getenv("client_secret"),
-//		Endpoint: oauth2.Endpoint{
-//			AuthURL:  "https://accounts.spotify.com/authorize",
-//			TokenURL: "https://accounts.spotify.com/api/token",
-//		},
-//
-//		RedirectURL: "http://localhost:3000/spotify/songs",
-//		Scopes:      []string{},
-//	}
-//
-//	url := config.AuthCodeURL("state")
-//	log.Println(url)
-//
-//	w.Header().Set("Content-Type", "application/json")
-//
-//	v, err := json.Marshal(url)
-//	if err != nil {
-//		fmt.Println(err)
-//	}
-//	log.Println(v)
-//	b, err := JSONSafeMarshal(url, true)
-//	if err != nil {
-//		//c.AbortWithStatus(http.StatusInternalServerError)
-//		//return
-//		log.Println("Marshal取得失敗")
-//	}
-//	//log.Println(v)
-//	w.Write(b)
-//}
-
 func main() {
 	err := godotenv.Load()
 	if err != nil {
@@ -474,10 +425,9 @@ func main() {
 
 	r.Handle("/api/song", JwtMiddleware.Handler(&CreateSongHandler{DB: db})).Methods("POST")
 
-	r.Handle("/api/getRedirectUrl", JwtMiddleware.Handler(&controller.GetRedirectURL{DB: db})).Methods("GET")
-	r.Handle("/api/getToken", JwtMiddleware.Handler(&controller.GetToken{DB: db})).Methods("POST")
-	r.Handle("/api/tracks", JwtMiddleware.Handler(&controller.GetTracks{DB: db})).Methods("POST")
-	//r.HandleFunc("/api/tracks", controller.GetTracks).Methods("POST")
+	r.HandleFunc("/api/getRedirectUrl", controller.GetRedirectURL).Methods("GET")
+	r.HandleFunc("/api/getToken", controller.GetToken).Methods("POST")
+	r.HandleFunc("/api/tracks", controller.GetTracks).Methods("POST")
 
 	if err := http.ListenAndServe(":8081", r); err != nil {
 		log.Println(err)

--- a/main.go
+++ b/main.go
@@ -410,7 +410,13 @@ type GetSongHandler struct {
 
 func (f *GetSongHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["id"]
+	id, ok := vars["id"]
+	if !ok {
+		var error model.Error
+		error.Message = "idの取得に失敗しました"
+		errorInResponse(w, http.StatusBadRequest, error)
+		return
+	}
 
 	var song model.Song
 
@@ -473,7 +479,13 @@ type UpdateSongHandler struct {
 
 func (f *UpdateSongHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["id"]
+	id, ok := vars["id"]
+	if !ok {
+		var error model.Error
+		error.Message = "idの取得に失敗しました"
+		errorInResponse(w, http.StatusBadRequest, error)
+		return
+	}
 
 	dec := json.NewDecoder(r.Body)
 	var d model.Song
@@ -508,7 +520,13 @@ type DeleteSongHandler struct {
 
 func (f *DeleteSongHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["id"]
+	id, ok := vars["id"]
+	if !ok {
+		var error model.Error
+		error.Message = "idの取得に失敗しました"
+		errorInResponse(w, http.StatusBadRequest, error)
+		return
+	}
 
 	var song model.Song
 

--- a/model/type.go
+++ b/model/type.go
@@ -46,3 +46,92 @@ type Error struct {
 type Auth struct {
 	Email string
 }
+
+type Form struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type Code struct {
+	Code string
+}
+
+type SearchTitle struct {
+	Title string
+	Token string
+}
+
+type Tracks struct {
+	Tracks struct {
+		Href  string `json:"href"`
+		Items []struct {
+			Album struct {
+				AlbumType string `json:"album_type"`
+				Artists   []struct {
+					ExternalUrls struct {
+						Spotify string `json:"spotify"`
+					} `json:"external_urls"`
+					Href string `json:"href"`
+					ID   string `json:"id"`
+					Name string `json:"name"`
+					Type string `json:"type"`
+					URI  string `json:"uri"`
+				} `json:"artists"`
+				ExternalUrls struct {
+					Spotify string `json:"spotify"`
+				} `json:"external_urls"`
+				Href   string `json:"href"`
+				ID     string `json:"id"`
+				Images []struct {
+					Height int    `json:"height"`
+					URL    string `json:"url"`
+					Width  int    `json:"width"`
+				} `json:"images"`
+				Name                 string `json:"name"`
+				ReleaseDate          string `json:"release_date"`
+				ReleaseDatePrecision string `json:"release_date_precision"`
+				TotalTracks          int    `json:"total_tracks"`
+				Type                 string `json:"type"`
+				URI                  string `json:"uri"`
+			} `json:"album"`
+			Artists []struct {
+				ExternalUrls struct {
+					Spotify string `json:"spotify"`
+				} `json:"external_urls"`
+				Href string `json:"href"`
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Type string `json:"type"`
+				URI  string `json:"uri"`
+			} `json:"artists"`
+			DiscNumber  int  `json:"disc_number"`
+			DurationMs  int  `json:"duration_ms"`
+			Explicit    bool `json:"explicit"`
+			ExternalIds struct {
+				Isrc string `json:"isrc"`
+			} `json:"external_ids"`
+			ExternalUrls struct {
+				Spotify string `json:"spotify"`
+			} `json:"external_urls"`
+			Href        string `json:"href"`
+			ID          string `json:"id"`
+			IsLocal     bool   `json:"is_local"`
+			IsPlayable  bool   `json:"is_playable"`
+			Name        string `json:"name"`
+			Popularity  int    `json:"popularity"`
+			PreviewURL  string `json:"preview_url"`
+			TrackNumber int    `json:"track_number"`
+			Type        string `json:"type"`
+			URI         string `json:"uri"`
+		} `json:"items"`
+		Limit    int         `json:"limit"`
+		Next     string      `json:"next"`
+		Offset   int         `json:"offset"`
+		Previous interface{} `json:"previous"`
+		Total    int         `json:"total"`
+	} `json:"tracks"`
+}
+
+type Response struct {
+	Tracks Tracks `json:"tracks"`
+}

--- a/model/type.go
+++ b/model/type.go
@@ -18,6 +18,22 @@ type User struct {
 	Password         string     `json:"-"`
 }
 
+type Song struct {
+	ID             uint       `json:"id"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      time.Time  `json:"updatedAt"`
+	DeletedAt      *time.Time `json:"deletedAt"`
+	Title          string     `json:"title"`
+	Artist         string     `json:"artist"`
+	MusicAge       int        `json:"musicAge"`
+	Image          string     `json:"image"`
+	Video          string     `json:"video"`
+	Album          string     `json:"album"`
+	Description    string     `json:"description"`
+	SpotifyTrackId string     `json:"spotifyTrackId"`
+	UserID         uint       `json:"userId"`
+}
+
 type JWT struct {
 	Token string `json:"token"`
 }

--- a/service/spotify.go
+++ b/service/spotify.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"golang-songs/model"
 )
@@ -28,7 +29,9 @@ func GetTracks(token string, title string) (*model.Response, error) {
 	//ヘッダに」アクセストークン入れている
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/service/spotify.go
+++ b/service/spotify.go
@@ -44,7 +44,6 @@ func GetTracks(token string, title string) (*model.Response, error) {
 
 	var tracks model.Tracks
 
-	json.Unmarshal(b, &tracks)
 	if err := json.Unmarshal(b, &tracks); err != nil {
 		return nil, err
 	}

--- a/service/spotify.go
+++ b/service/spotify.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"golang-songs/model"
+)
+
+func GetTracks(token string, title string) (*model.Response, error) {
+
+	values := url.Values{}
+
+	values.Add("type", "track")
+	values.Add("q", title)
+	values.Add("market", "JP")
+	values.Add("limit", "10")
+
+	req, err := http.NewRequest("GET", "https://api.spotify.com/v1/search", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.RawQuery = values.Encode()
+
+	//ヘッダに」アクセストークン入れている
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var tracks model.Tracks
+
+	json.Unmarshal(b, &tracks)
+	if err := json.Unmarshal(b, &tracks); err != nil {
+		return nil, err
+	}
+
+	response := &model.Response{
+		Tracks: tracks,
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
**SpotifyAPIを用いた曲検索機能の作成**
ClientIDやClientSecretを.envファイルから取得し、それらの情報をもとにSpotifyのRedirectURLを返す。
フロントにてRedirectURLを踏んだあと取得できるコードを元に、Spotifyからアクセストークンを取得しフロントに返す。（フロントでアクセストークンをクッキーに保存）

アクセストークンを元にSpotifyAPIを用いて、曲を曲名で検索。

**データベースに曲情報のテーブル作成**
IDを主キーとし、user_idをusersテーブルのidに対する外部キーとしている。

**構造体Songの作成**

**その他構造体の追加**
SearchTitle　曲名での曲検索に使用

Tracks　検索で取得した曲（トラック）一覧を格納

Response 検索で取得した曲（トラック）一覧を返すのに使用

**曲のCRUDのAPI作成**

- 曲を追加するAPI

- IDで指定された曲の情報を返すAPI

- 全ての曲を返すAPI

- IDで指定された曲の情報を更新するAPI

- IDで指定された曲を削除するAPI