### PR TITLE
お気に入り登録・解除機能の追加/ ユーザー情報に登録済みの曲を持たせる #13

### DIFF
--- a/db/migrations/20200426211110-create_users.sql
+++ b/db/migrations/20200426211110-create_users.sql
@@ -1,7 +1,7 @@
 
 -- +migrate Up
 CREATE TABLE IF NOT EXISTS users (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT UNSIGNED NOT NULL,
+    id BIGINT AUTO_INCREMENT NOT NULL,
     name varchar(255),
     email varchar(255) NOT NULL unique,
     age int,

--- a/db/migrations/20200523113833-create_bookmarks.sql
+++ b/db/migrations/20200523113833-create_bookmarks.sql
@@ -1,0 +1,15 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS bookmarks (
+    id BIGINT AUTO_INCREMENT NOT NULL,
+    user_id BIGINT NOT NULL,
+    song_id BIGINT NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NOT NULL,
+    deleted_at timestamp,
+    PRIMARY KEY (id),
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(song_id) REFERENCES songs(id)
+);
+-- +migrate Down
+DROP TABLE IF EXISTS bookmarks;

--- a/main.go
+++ b/main.go
@@ -243,6 +243,22 @@ func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bookmarkings := []model.Song{}
+
+	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
+		var error model.Error
+		error.Message = "該当する参照が見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	if f.DB.Model(&user).Related(&bookmarkings, "Bookmarikings").RecordNotFound() {
+		error := model.Error{}
+		error.Message = "レコードが見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
 	v, err := json.Marshal(user)
 	if err != nil {
 		var error model.Error
@@ -282,6 +298,23 @@ func (f *GetUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		errorInResponse(w, http.StatusUnauthorized, error)
 		return
 	}
+
+	bookmarkings := []model.Song{}
+
+	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
+		var error model.Error
+		error.Message = "該当する参照が見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	if f.DB.Model(&user).Related(&bookmarkings, "Bookmarikings").RecordNotFound() {
+		error := model.Error{}
+		error.Message = "レコードが見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
 	v, err := json.Marshal(user)
 	if err != nil {
 		var error model.Error
@@ -591,15 +624,6 @@ func (f *BookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dec := json.NewDecoder(r.Body)
-	var d model.Song
-	if err := dec.Decode(&d); err != nil {
-		var error model.Error
-		error.Message = "リクエストボディのデコードに失敗しました。"
-		errorInResponse(w, http.StatusInternalServerError, error)
-		return
-	}
-
 	var song model.Song
 	if err := f.DB.Where("id = ?", id).Find(&song).Error; gorm.IsRecordNotFoundError(err) {
 		error := model.Error{}
@@ -608,16 +632,37 @@ func (f *BookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	header_hoge := r.Header.Get("Authorization")
-	bearerToken := strings.Split(header_hoge, " ")
+	headerAuthorization := r.Header.Get("Authorization")
+	if len(headerAuthorization) == 0 {
+		var error model.Error
+		error.Message = "認証トークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	bearerToken := strings.Split(headerAuthorization, " ")
+	if len(bearerToken) < 2 {
+		var error model.Error
+		error.Message = "bearerトークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusUnauthorized, error)
+		return
+	}
+
 	authToken := bearerToken[1]
 
-	parsedToken, _ := Parse(authToken)
+	parsedToken, err := Parse(authToken)
+	if err != nil {
+		var error model.Error
+		error.Message = "認証コードのパースに失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
 	userEmail := parsedToken.Email
 
 	var user model.User
 	if err := f.DB.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
-		error := model.Error{}
+		var error model.Error
 		error.Message = "該当するアカウントが見つかりません。"
 		errorInResponse(w, http.StatusUnauthorized, error)
 		return
@@ -632,21 +677,19 @@ func (f *BookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	f.DB.Preload("Bookmarkings").Find(&user)
-	f.DB.Model(&user).Association("Bookmarkings").Append(&song)
+	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
+		var error model.Error
+		error.Message = "該当する参照が見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 
-	//nの値は増えてる
-	n := f.DB.Model(&user).Association("Bookmarkings").Count() //動作
-	log.Println("n:", n)
-
-	log.Println("user:", user)
-
-	log.Println("==============")
-	bookmarkings := []model.Song{}
-	f.DB.Model(&user).Related(&bookmarkings, "Bookmarikings")
-
-	log.Println("user:", user)
-	log.Println("bookmarkings:", bookmarkings)
+	if err := f.DB.Model(&user).Association("Bookmarkings").Append(&song).Error; err != nil {
+		error := model.Error{}
+		error.Message = "参照の追加に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 }
 
 type RemoveBookmarkHandler struct {
@@ -655,11 +698,13 @@ type RemoveBookmarkHandler struct {
 
 func (f *RemoveBookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["id"]
-
-	dec := json.NewDecoder(r.Body)
-	var d model.Song
-	dec.Decode(&d)
+	id, ok := vars["id"]
+	if !ok {
+		var error model.Error
+		error.Message = "idの取得に失敗しました"
+		errorInResponse(w, http.StatusBadRequest, error)
+		return
+	}
 
 	var song model.Song
 
@@ -670,8 +715,22 @@ func (f *RemoveBookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	header_hoge := r.Header.Get("Authorization")
-	bearerToken := strings.Split(header_hoge, " ")
+	headerAuthorization := r.Header.Get("Authorization")
+	if len(headerAuthorization) == 0 {
+		var error model.Error
+		error.Message = "認証トークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
+
+	bearerToken := strings.Split(headerAuthorization, " ")
+	if len(bearerToken) < 2 {
+		var error model.Error
+		error.Message = "bearerトークンの取得に失敗しました。"
+		errorInResponse(w, http.StatusUnauthorized, error)
+		return
+	}
+
 	authToken := bearerToken[1]
 
 	parsedToken, err := Parse(authToken)
@@ -681,10 +740,10 @@ func (f *RemoveBookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		errorInResponse(w, http.StatusInternalServerError, error)
 		return
 	}
+
 	userEmail := parsedToken.Email
 
 	var user model.User
-
 	if err := f.DB.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
 		error := model.Error{}
 		error.Message = "該当するアカウントが見つかりません。"
@@ -692,21 +751,19 @@ func (f *RemoveBookmarkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	f.DB.Preload("Bookmarkings").Find(&user)
-	f.DB.Model(&user).Association("Bookmarkings").Delete(&song)
+	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
+		var error model.Error
+		error.Message = "該当する参照が見つかりません。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 
-	//nの値は増えてる
-	n := f.DB.Model(&user).Association("Bookmarkings").Count() //動作
-	log.Println("n:", n)
-
-	log.Println("user:", user)
-
-	log.Println("==============")
-	bookmarkings := []model.Song{}
-	f.DB.Model(&user).Related(&bookmarkings, "Bookmarikings")
-
-	log.Println("user:", user)
-	log.Println("bookmarkings:", bookmarkings)
+	if err := f.DB.Model(&user).Association("Bookmarkings").Delete(&song).Error; err != nil {
+		error := model.Error{}
+		error.Message = "参照の削除に失敗しました。"
+		errorInResponse(w, http.StatusInternalServerError, error)
+		return
+	}
 }
 
 //ELBのヘルスチェック用のハンドラ
@@ -749,6 +806,9 @@ func main() {
 	r.HandleFunc("/api/getRedirectUrl", controller.GetRedirectURL).Methods("GET")
 	r.HandleFunc("/api/getToken", controller.GetToken).Methods("POST")
 	r.HandleFunc("/api/tracks", controller.GetTracks).Methods("POST")
+
+	r.Handle("/api/song/{id}/bookmark", JwtMiddleware.Handler(&BookmarkHandler{DB: db})).Methods("POST")
+	r.Handle("/api/song/{id}/removeBookmark", JwtMiddleware.Handler(&RemoveBookmarkHandler{DB: db})).Methods("POST")
 
 	r.HandleFunc("/", healthzHandler).Methods("GET")
 

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func (f *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bookmarkings := []model.Song{}
+	var bookmarkings []model.Song
 
 	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
 		var error model.Error
@@ -299,7 +299,7 @@ func (f *GetUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bookmarkings := []model.Song{}
+	var bookmarkings []model.Song
 
 	if err := f.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
 		var error model.Error
@@ -803,12 +803,12 @@ func main() {
 	r.Handle("/api/song/{id}", JwtMiddleware.Handler(&UpdateSongHandler{DB: db})).Methods("PUT")
 	r.Handle("/api/song/{id}", JwtMiddleware.Handler(&DeleteSongHandler{DB: db})).Methods("DELETE")
 
-	r.HandleFunc("/api/getRedirectUrl", controller.GetRedirectURL).Methods("GET")
-	r.HandleFunc("/api/getToken", controller.GetToken).Methods("POST")
+	r.HandleFunc("/api/get-redirect-url", controller.GetRedirectURL).Methods("GET")
+	r.HandleFunc("/api/get-token", controller.GetToken).Methods("POST")
 	r.HandleFunc("/api/tracks", controller.GetTracks).Methods("POST")
 
 	r.Handle("/api/song/{id}/bookmark", JwtMiddleware.Handler(&BookmarkHandler{DB: db})).Methods("POST")
-	r.Handle("/api/song/{id}/removeBookmark", JwtMiddleware.Handler(&RemoveBookmarkHandler{DB: db})).Methods("POST")
+	r.Handle("/api/song/{id}/remove-bookmark", JwtMiddleware.Handler(&RemoveBookmarkHandler{DB: db})).Methods("POST")
 
 	r.HandleFunc("/", healthzHandler).Methods("GET")
 

--- a/model/type.go
+++ b/model/type.go
@@ -33,7 +33,6 @@ type Song struct {
 	Description    string     `json:"description"`
 	SpotifyTrackId string     `json:"spotifyTrackId"`
 	UserID         uint       `json:"userId"`
-	Bookmarkers    []*User    `json:"bookmarkers" gorm:"many2many:bookmarks;"`
 }
 
 type Bookmark struct {

--- a/model/type.go
+++ b/model/type.go
@@ -16,6 +16,7 @@ type User struct {
 	FavoriteArtist   string     `json:"favoriteArtist"`
 	Comment          string     `json:"comment"`
 	Password         string     `json:"-"`
+	Bookmarkings     []*Song    `json:"bookmarkings" gorm:"many2many:bookmarks;"`
 }
 
 type Song struct {
@@ -32,6 +33,16 @@ type Song struct {
 	Description    string     `json:"description"`
 	SpotifyTrackId string     `json:"spotifyTrackId"`
 	UserID         uint       `json:"userId"`
+	Bookmarkers    []*User    `json:"bookmarkers" gorm:"many2many:bookmarks;"`
+}
+
+type Bookmark struct {
+	ID        uint       `json:"id"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
+	DeletedAt *time.Time `json:"deletedAt"`
+	UserID    uint       `json:"userId"`
+	SongID    uint       `json:"songId"`
 }
 
 type JWT struct {


### PR DESCRIPTION
- usersテーブルとsongsテーブルの中間テーブル「bookmarks」を作成。

- 構造体Bookmarkを作成。

- 構造体UserにフィールドBookmarkingsを追加。

- リレーション名は「Bookmarkings」

- 曲をお気に入りに登録するハンドラ「BookmarkHandler」とお気に入り解除するハンドラ「RemoveBookmarkHandler」を作成。

- ハンドラGetUserHandlerとUserHandlerで返す値に、ユーザーのお気に入り登録済み曲一覧を追加。

- usersテーブルのidカラムについて不要な記述を削除
