### PR TITLE
#131 HTTPサーバのgraceful shutdownを実装 #131

### DIFF
--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -57,7 +57,6 @@ func Dispatch(DB *gorm.DB, Redis redis.Conn) {
 
 	r.HandleFunc("/", healthzHandler).Methods("GET")
 
-	//引数を追加した
 	os.Exit(run(context.Background(), r))
 }
 
@@ -79,7 +78,6 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-//引数を追加した
 func run(ctx context.Context, r *mux.Router) int {
 	var eg *errgroup.Group
 	eg, ctx = errgroup.WithContext(ctx)
@@ -118,7 +116,7 @@ func acceptSignal(ctx context.Context) error {
 
 func runServer(ctx context.Context, r *mux.Router) error {
 	s := &http.Server{
-		Addr:    ":8082",
+		Addr:    ":8080",
 		Handler: r,
 	}
 

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -1,12 +1,17 @@
 package infrastructure
 
 import (
+	"context"
+	"fmt"
 	"golang-songs/interfaces"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/jinzhu/gorm"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/garyburd/redigo/redis"
 
@@ -52,9 +57,8 @@ func Dispatch(DB *gorm.DB, Redis redis.Conn) {
 
 	r.HandleFunc("/", healthzHandler).Methods("GET")
 
-	if err := http.ListenAndServe(":8080", r); err != nil {
-		log.Println(err)
-	}
+	//引数を追加した
+	os.Exit(run(context.Background(), r))
 }
 
 var JwtMiddleware = jwtmiddleware.New(jwtmiddleware.Options{
@@ -73,4 +77,63 @@ var JwtMiddleware = jwtmiddleware.New(jwtmiddleware.Options{
 //ELBのヘルスチェック用のハンドラ
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
+}
+
+//引数を追加した
+func run(ctx context.Context, r *mux.Router) int {
+	var eg *errgroup.Group
+	eg, ctx = errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return runServer(ctx, r)
+	})
+	eg.Go(func() error {
+		return acceptSignal(ctx)
+	})
+	eg.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	if err := eg.Wait(); err != nil {
+		log.Println(err)
+		return 1
+	}
+	return 0
+}
+
+func acceptSignal(ctx context.Context) error {
+	sigCh := make(chan os.Signal, 1)
+	//signalをハンドリングする。SIGINTとSIGTERMの両方
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case <-ctx.Done():
+		signal.Reset()
+		return nil
+	case sig := <-sigCh:
+		return fmt.Errorf("signal received: %v", sig.String())
+	}
+}
+
+func runServer(ctx context.Context, r *mux.Router) error {
+	s := &http.Server{
+		Addr:    ":8082",
+		Handler: r,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		defer close(errCh)
+		if err := s.ListenAndServe(); err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return s.Shutdown(ctx)
+	case err := <-errCh:
+		return err
+	}
 }

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -108,7 +108,7 @@ func acceptSignal(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		signal.Reset()
-		return nil
+		return ctx.Err()
 	case sig := <-sigCh:
 		return fmt.Errorf("signal received: %v", sig.String())
 	}


### PR DESCRIPTION
**概要**

x/sync/errgroupパッケージを用いて、goroutine をグループ化しそのエラー処理を取り纏めています。

  - errgroup.Group 型の値(0値が使用可能)を用意する

  - errgroup.Group.Go() で error を返す関数を goroutine として起動する

  - errgroup.Group.Wait() で errgroup.Group.Go() で起動した goroutine の全てが終了するまで待機し、一番最初に返ってきた non-nil error を返す。
  - errgroup.WithContext() で初期化をしておくことで、最初に non-nil error が返ってきた瞬間に context がキャンセルされるように。

 os/signalパッケージを用いてシグナルハンドリングしています。
- SIGINTやSIGTERMを受けると HTTP サーバを graceful shutdown。
- signal.Notifyにわたすチャネルはバッファをつけています。