### PR TITLE
#163 曲関連のAPIにおいて多層キャッシュ構造実装

### DIFF
--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -21,10 +21,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func Dispatch(DB *gorm.DB, Redis redis.Conn) {
+func Dispatch(DB *gorm.DB, Redis redis.Conn, SidecarRedis redis.Conn) {
 	authController := interfaces.NewAuthController(DB)
 	userController := interfaces.NewUserController(DB)
-	songController := interfaces.NewSongController(DB, Redis)
+	songController := interfaces.NewSongController(DB, Redis, SidecarRedis)
 	bookmarkController := interfaces.NewBookmarkController(DB)
 	userFollowController := interfaces.NewUserFollowController(DB)
 	spotifyController := interfaces.NewSpotifyController(DB)
@@ -116,7 +116,8 @@ func acceptSignal(ctx context.Context) error {
 
 func runServer(ctx context.Context, r *mux.Router) error {
 	s := &http.Server{
-		Addr:    ":8080",
+		Addr: ":8082",
+		//Addr:    ":8080",
 		Handler: r,
 	}
 

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -116,8 +116,7 @@ func acceptSignal(ctx context.Context) error {
 
 func runServer(ctx context.Context, r *mux.Router) error {
 	s := &http.Server{
-		Addr: ":8082",
-		//Addr:    ":8080",
+		Addr:    ":8080",
 		Handler: r,
 	}
 

--- a/interfaces/song_controller.go
+++ b/interfaces/song_controller.go
@@ -19,12 +19,13 @@ type SongController struct {
 	SongInteractor usecases.SongInteractor
 }
 
-func NewSongController(DB *gorm.DB, Redis redis.Conn) *SongController {
+func NewSongController(DB *gorm.DB, Redis redis.Conn, SidecarRedis redis.Conn) *SongController {
 	return &SongController{
 		SongInteractor: usecases.SongInteractor{
 			SongRepository: &SongRepository{
-				DB:    DB,
-				Redis: Redis,
+				DB:           DB,
+				Redis:        Redis,
+				SidecarRedis: SidecarRedis,
 			},
 		},
 	}

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -3,7 +3,6 @@ package interfaces
 import (
 	"fmt"
 	"golang-songs/model"
-	"log"
 	"strconv"
 	"time"
 
@@ -138,7 +137,6 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 
 		//リモートのRedisにキャッシュが存在する場合
 		if exists > 0 {
-			log.Println("リモートにキャッシュあり")
 			// リモートのRedisのキャッシュを取得
 			t, err := GetSongByID(songID, sr.Redis)
 			if err != nil {
@@ -207,22 +205,16 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 			if err != nil {
 				return nil, err
 			}
-
-			log.Println("リモートから取ってきてサイドカーに保存完了")
 		} else {
-			log.Println("リモートにもサイドカーにも値なし")
 			//リモートのRedisにキャッシュが存在しない場合RDSに値を取りに行く。
 			result := sr.DB.Where("id = ?", songID).Find(&song)
 
 			//RDSからの値取得に成功した場合
 			if result.Error == nil {
-				//Redisに保存する前にformatする
-				formattedCreatedAt := song.CreatedAt.Format("2006年01月02日 15時04分05秒")
-				formattedUpdatedAt := song.UpdatedAt.Format("2006年01月02日 15時04分05秒")
 				t := map[string]string{
 					"ID":             strconv.Itoa(songID),
-					"CreatedAt":      formattedCreatedAt,
-					"UpdatedAt":      formattedUpdatedAt,
+					"CreatedAt":      song.CreatedAt.Format("2006年01月02日 15時04分05秒"),
+					"UpdatedAt":      song.UpdatedAt.Format("2006年01月02日 15時04分05秒"),
 					"DeletedAt":      "",
 					"Title":          song.Title,
 					"Artist":         song.Artist,
@@ -294,15 +286,11 @@ func (sr *SongRepository) Save(userEmail string, p model.Song) error {
 			return scanResult.Error
 		}
 
-		//Redisに入れる前にformatする
-		formattedCreatedAt := song.CreatedAt.Format("2006年01月02日 15時04分05秒")
-		formattedUpdatedAt := song.UpdatedAt.Format("2006年01月02日 15時04分05秒")
-
 		//mapに変換
 		t := map[string]string{
 			"ID":             strconv.Itoa(int(song.ID)),
-			"CreatedAt":      formattedCreatedAt,
-			"UpdatedAt":      formattedUpdatedAt,
+			"CreatedAt":      song.CreatedAt.Format("2006年01月02日 15時04分05秒"),
+			"UpdatedAt":      song.UpdatedAt.Format("2006年01月02日 15時04分05秒"),
 			"DeletedAt":      "",
 			"Title":          song.Title,
 			"Artist":         song.Artist,
@@ -372,15 +360,11 @@ func (sr *SongRepository) UpdateByID(userEmail string, songID int, p model.Song)
 			return scanResult.Error
 		}
 
-		//Redisに入れる前にformatする
-		formattedCreatedAt := updatedSong.CreatedAt.Format("2006年01月02日 15時04分05秒")
-		formattedUpdatedAt := updatedSong.UpdatedAt.Format("2006年01月02日 15時04分05秒")
-
 		//mapに変換
 		t := map[string]string{
 			"ID":             strconv.Itoa(int(updatedSong.ID)),
-			"CreatedAt":      formattedCreatedAt,
-			"UpdatedAt":      formattedUpdatedAt,
+			"CreatedAt":      updatedSong.CreatedAt.Format("2006年01月02日 15時04分05秒"),
+			"UpdatedAt":      updatedSong.UpdatedAt.Format("2006年01月02日 15時04分05秒"),
 			"DeletedAt":      "",
 			"Title":          updatedSong.Title,
 			"Artist":         updatedSong.Artist,

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -146,7 +146,6 @@ func (sr *SongRepository) FindAll() (*[]model.Song, error) {
 }
 
 func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
-	//var song model.Song
 	var song model.Song
 
 	//singleflightで同時関数呼び出しを1度に抑える

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -105,12 +105,11 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 				return nil, err
 			}
 			uintID := uint(intID)
+
+			intUserId, err := strconv.Atoi(t["UserID"])
 			if err != nil {
 				return nil, err
 			}
-
-			intUserId, err := strconv.Atoi(t["UserID"])
-			uintUserID := uint(intUserId)
 
 			//MusicAgeをstringからintに変換
 			MusicAge, err := strconv.Atoi(t["MusicAge"])
@@ -128,7 +127,7 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 				Album:          t["Album"],
 				Description:    t["Description"],
 				SpotifyTrackId: t["SpotifyTrackId"],
-				UserID:         uintUserID,
+				UserID:         uint(intUserId),
 				CreatedAt:      CreatedAt,
 				UpdatedAt:      UpdatedAt,
 				DeletedAt:      nil,
@@ -148,8 +147,6 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 					return nil, err
 				}
 
-				//予めtime.Localにタイムゾーンの設定情報を入れておく
-				time.Local = time.FixedZone("Local", 9*60*60)
 				//ロケーションを指定して、パース
 				jst, err := time.LoadLocation("Local")
 				if err != nil {
@@ -171,11 +168,10 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 					return nil, err
 				}
 				uintID := uint(intID)
+				intUserId, err := strconv.Atoi(t["UserID"])
 				if err != nil {
 					return nil, err
 				}
-				intUserId, err := strconv.Atoi(t["UserID"])
-				uintUserID := uint(intUserId)
 
 				//MusicAgeをstringからintに変換
 				MusicAge, err := strconv.Atoi(t["MusicAge"])
@@ -193,7 +189,7 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 					Album:          t["Album"],
 					Description:    t["Description"],
 					SpotifyTrackId: t["SpotifyTrackId"],
-					UserID:         uintUserID,
+					UserID:         uint(intUserId),
 					CreatedAt:      CreatedAt,
 					UpdatedAt:      UpdatedAt,
 					DeletedAt:      nil,

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -258,22 +258,8 @@ func (sr *SongRepository) Save(userEmail string, p model.Song) error {
 			return scanResult.Error
 		}
 
-		//mapに変換
-		t := map[string]string{
-			"ID":             strconv.Itoa(int(song.ID)),
-			"CreatedAt":      song.CreatedAt.Format("2006年01月02日 15時04分05秒"),
-			"UpdatedAt":      song.UpdatedAt.Format("2006年01月02日 15時04分05秒"),
-			"DeletedAt":      "",
-			"Title":          song.Title,
-			"Artist":         song.Artist,
-			"MusicAge":       strconv.Itoa(song.MusicAge),
-			"Image":          song.Image,
-			"Video":          song.Video,
-			"Album":          song.Album,
-			"Description":    song.Description,
-			"SpotifyTrackId": song.SpotifyTrackId,
-			"UserID":         strconv.Itoa(int(song.UserID)),
-		}
+		// 曲情報をmapへと変換
+		t := rdsSongToMap(song)
 
 		//リモートのRedisに入れる。キャッシュのTTLは1800秒(30分)
 		err := SetSongByID(int(song.ID), t, sr.Redis, 1800)
@@ -321,22 +307,8 @@ func (sr *SongRepository) UpdateByID(userEmail string, songID int, p model.Song)
 			return scanResult.Error
 		}
 
-		//mapに変換
-		t := map[string]string{
-			"ID":             strconv.Itoa(int(updatedSong.ID)),
-			"CreatedAt":      updatedSong.CreatedAt.Format("2006年01月02日 15時04分05秒"),
-			"UpdatedAt":      updatedSong.UpdatedAt.Format("2006年01月02日 15時04分05秒"),
-			"DeletedAt":      "",
-			"Title":          updatedSong.Title,
-			"Artist":         updatedSong.Artist,
-			"MusicAge":       strconv.Itoa(updatedSong.MusicAge),
-			"Image":          updatedSong.Image,
-			"Video":          updatedSong.Video,
-			"Album":          updatedSong.Album,
-			"Description":    updatedSong.Description,
-			"SpotifyTrackId": updatedSong.SpotifyTrackId,
-			"UserID":         strconv.Itoa(int(updatedSong.UserID)),
-		}
+		// 曲情報をmapへと変換
+		t := rdsSongToMap(updatedSong)
 
 		//リモートのRedisに保存。キャッシュのTTLは1800秒(30分)
 		err := SetSongByID(int(updatedSong.ID), t, sr.Redis, 1800)

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -12,8 +12,44 @@ import (
 )
 
 type SongRepository struct {
-	DB    *gorm.DB
-	Redis redis.Conn
+	DB           *gorm.DB
+	Redis        redis.Conn
+	SidecarRedis redis.Conn
+}
+
+//キャッシュが存在するか確認
+func ExistsSongByID(songID int, rc redis.Conn) (int, error) {
+	exists, err := redis.Int(rc.Do("EXISTS", fmt.Sprintf("song:%d", songID)))
+	if err != nil {
+		return 0, err
+	}
+	return exists, nil
+}
+
+//func GetSongByID(songID int, rc redis.Conn) (*model.Song, error) {
+func GetSongByID(songID int, rc redis.Conn) (map[string]string, error) {
+	t, err := redis.StringMap(rc.Do("HGETALL", fmt.Sprintf("song:%d", songID)))
+	if err != nil {
+		log.Println("キャッシュ取得失敗GetSongByID")
+		return nil, err
+	}
+	log.Println("キャッシュ取得成功GetSongByID")
+
+	return t, nil
+}
+
+func SetSongByID(songID int, t map[string]string, rc redis.Conn) error {
+	log.Println("SetSongByID")
+	log.Println(t, &rc)
+	_, err := rc.Do("HMSET", fmt.Sprintf("song:%d", songID), "ID", t["ID"], "CreatedAt", t["CreatedAt"], "UpdatedAt", t["UpdatedAt"], "DeletedAt", t["DeletedAt"], "Title", t["Title"], "Artist", t["Artist"], "MusicAge", t["MusicAge"], "Image", t["Image"], "Video", t["Video"], "Album", t["Album"], "Description", t["Description"], "SpotifyTrackId", t["SpotifyTrackId"], "UserID", t["UserID"])
+	if err != nil {
+		log.Println("キャッシュ保存失敗SetSongByID")
+		log.Print(err)
+		return err
+	}
+	log.Println("キャッシュ保存成功SetSongByID")
+
+	return nil
 }
 
 func (sr *SongRepository) FindAll() (*[]model.Song, error) {
@@ -28,17 +64,26 @@ func (sr *SongRepository) FindAll() (*[]model.Song, error) {
 func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 	var song model.Song
 
-	exists, err := redis.Int(sr.Redis.Do("EXISTS", fmt.Sprintf("song:%d", songID)))
+	// サイドカーコンテナのRedisにキャッシュがあるか確認
+	exists, err := ExistsSongByID(songID, sr.SidecarRedis)
+	//exists, err := redis.Int(sr.Redis.Do("EXISTS", fmt.Sprintf("song:%d", songID)))
 	if err != nil {
 		return nil, err
 	}
-	//キャッシュが存在する場合
+	// サイドカーコンテナのRedisにキャッシュが存在する場合
 	if exists > 0 {
-		//log.Print("キャッシュが存在する")
-		t, err := redis.StringMap(sr.Redis.Do("HGETALL", fmt.Sprintf("song:%d", songID)))
+		log.Println("キャッシュあり")
+
+		// サイドカーのRedisのキャッシュを取得
+		t, err := GetSongByID(songID, sr.SidecarRedis)
 		if err != nil {
+			log.Println(err)
 			return nil, err
 		}
+
+		log.Println("キャッシュ取得成功2")
+
+		//return song, nil
 
 		//予めtime.Localにタイムゾーンの設定情報を入れておく
 		time.Local = time.FixedZone("Local", 9*60*60)
@@ -71,9 +116,13 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 			log.Println(err)
 			return nil, err
 		}
-		intUserId, err := strconv.Atoi(t["UserID"])
 
+		log.Printf("%v:%T", t, t)
+		log.Printf("%v:%T", t["UserID"], t["UserID"])
+		intUserId, err := strconv.Atoi(t["UserID"])
+		log.Printf("%v:%T", intUserId, intUserId)
 		uintUserID := uint(intUserId)
+		log.Printf("%v:%T", uintUserID, uintUserID)
 
 		//MusicAgeをstringからintに変換
 		MusicAge, err := strconv.Atoi(t["MusicAge"])
@@ -97,41 +146,160 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 			UpdatedAt:      UpdatedAt,
 			DeletedAt:      nil,
 		}
-
-		//キャッシュのTTLを1800秒(30分)にリセット
-		_, err = sr.Redis.Do("EXPIRE", fmt.Sprintf("song:%d", songID), "1800")
+	} else {
+		// サイドカーコンテナのRedisにキャッシュが存在しない場合、リモートのRedisにキャッシュがあるか確認
+		exists, err := ExistsSongByID(songID, sr.Redis)
 		if err != nil {
-			log.Println(err)
 			return nil, err
 		}
 
-		return &song, nil
-	} else {
-		//キャッシュが存在しない場合、DBに取りに行き、取得した値はRedisに保存する
-		result := sr.DB.Where("id = ?", songID).Find(&song)
+		//リモートのRedisにキャッシュが存在する場合
+		if exists > 0 {
+			log.Println("リモートにキャッシュあり")
+			// リモートのRedisのキャッシュを取得
+			t, err := GetSongByID(songID, sr.Redis)
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
 
-		if result.Error == nil {
-			//Redisに入れる前にformatする
-			formattedCreatedAt := song.CreatedAt.Format("2006年01月02日 15時04分05秒")
-			formattedUpdatedAt := song.UpdatedAt.Format("2006年01月02日 15時04分05秒")
+			//予めtime.Localにタイムゾーンの設定情報を入れておく
+			time.Local = time.FixedZone("Local", 9*60*60)
+			//ロケーションを指定して、パース
+			jst, err := time.LoadLocation("Local")
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
 
-			//Redisに保存
-			_, err := redis.String(sr.Redis.Do("HMSET", fmt.Sprintf("song:%d", songID), "ID", songID, "CreatedAt", formattedCreatedAt, "UpdatedAt", formattedUpdatedAt, "DeletedAt", nil, "Title", song.Title, "Artist", song.Artist, "MusicAge", song.MusicAge, "Image", song.Image, "Video", song.Video, "Album", song.Album, "Description", song.Description, "SpotifyTrackId", song.SpotifyTrackId, "UserID", song.UserID))
+			CreatedAt, err := time.ParseInLocation("2006年01月02日 15時04分05秒", t["CreatedAt"], jst)
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
+			UpdatedAt, err := time.ParseInLocation("2006年01月02日 15時04分05秒", t["UpdatedAt"], jst)
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
+
+			//IDとUserIDをstringからunitに変換
+			intID, err := strconv.Atoi(t["ID"])
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
+			uintID := uint(intID)
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
+			intUserId, err := strconv.Atoi(t["UserID"])
+
+			uintUserID := uint(intUserId)
+
+			//MusicAgeをstringからintに変換
+			MusicAge, err := strconv.Atoi(t["MusicAge"])
+			if err != nil {
+				log.Println(err)
+				return nil, err
+			}
+
+			song = model.Song{
+				ID:             uintID,
+				Title:          t["Title"],
+				Artist:         t["Artist"],
+				MusicAge:       MusicAge,
+				Image:          t["Image"],
+				Video:          t["Video"],
+				Album:          t["Album"],
+				Description:    t["Description"],
+				SpotifyTrackId: t["SpotifyTrackId"],
+				UserID:         uintUserID,
+				CreatedAt:      CreatedAt,
+				UpdatedAt:      UpdatedAt,
+				DeletedAt:      nil,
+			}
+
+			//サイドカーコンテナのRedisに保存
+			err = SetSongByID(songID, t, sr.SidecarRedis)
+			//_, err := redis.String(sr.SidecarRedis.Do("HMSET", fmt.Sprintf("song:%d", songID), "ID", songID, "CreatedAt", formattedCreatedAt, "UpdatedAt", formattedUpdatedAt, "DeletedAt", nil, "Title", song.Title, "Artist", song.Artist, "MusicAge", song.MusicAge, "Image", song.Image, "Video", song.Video, "Album", song.Album, "Description", song.Description, "SpotifyTrackId", song.SpotifyTrackId, "UserID", song.UserID))
 			if err != nil {
 				return nil, err
 			}
 
 			//キャッシュのTTLを1800秒(30分)に設定
-			_, err = sr.Redis.Do("EXPIRE", fmt.Sprintf("song:%d", songID), "1800")
+			_, err = sr.SidecarRedis.Do("EXPIRE", fmt.Sprintf("song:%d", songID), "1800")
 			if err != nil {
 				return nil, err
 			}
 
-			return &song, nil
+			log.Println("リモートから取ってきてサイドカーに保存完了")
+
+			//return song, nil
 		} else {
-			return nil, result.Error
+			log.Println("リモートにもサイドカーにも値なし")
+			//リモートのRedisにキャッシュが存在しない場合RDSに値を取りに行く。
+			result := sr.DB.Where("id = ?", songID).Find(&song)
+
+			//RDSからの値取得に成功した場合
+			if result.Error == nil {
+				//Redisに保存する前にformatする
+				formattedCreatedAt := song.CreatedAt.Format("2006年01月02日 15時04分05秒")
+				formattedUpdatedAt := song.UpdatedAt.Format("2006年01月02日 15時04分05秒")
+				log.Printf("%v:%T", songID, songID)
+				log.Printf("%v:%T", song.MusicAge, song.MusicAge)
+				t := map[string]string{
+					"ID":             strconv.Itoa(songID),
+					"CreatedAt":      formattedCreatedAt,
+					"UpdatedAt":      formattedUpdatedAt,
+					"DeletedAt":      "",
+					"Title":          song.Title,
+					"Artist":         song.Artist,
+					"MusicAge":       strconv.Itoa(song.MusicAge),
+					"Image":          song.Image,
+					"Video":          song.Video,
+					"Album":          song.Album,
+					"Description":    song.Description,
+					"SpotifyTrackId": song.SpotifyTrackId,
+					"UserID":         strconv.Itoa(int(song.UserID)),
+				}
+				log.Printf("%v", t)
+
+				//リモートのRedisに保存
+				err = SetSongByID(songID, t, sr.Redis)
+				//_, err := redis.String(sr.Redis.Do("HMSET", fmt.Sprintf("song:%d", songID), "ID", songID, "CreatedAt", formattedCreatedAt, "UpdatedAt", formattedUpdatedAt, "DeletedAt", nil, "Title", song.Title, "Artist", song.Artist, "MusicAge", song.MusicAge, "Image", song.Image, "Video", song.Video, "Album", song.Album, "Description", song.Description, "SpotifyTrackId", song.SpotifyTrackId, "UserID", song.UserID))
+				if err != nil {
+					return nil, err
+				}
+				//キャッシュのTTLを1800秒(30分)に設定
+				_, err = sr.Redis.Do("EXPIRE", fmt.Sprintf("song:%d", songID), "1800")
+				if err != nil {
+					return nil, err
+				}
+
+				//サイドカーコンテナのRedisに保存
+				err = SetSongByID(songID, t, sr.SidecarRedis)
+				//_, err = redis.String(sr.SidecarRedis.Do("HMSET", fmt.Sprintf("song:%d", songID), t))
+				//_, err = redis.String(sr.SidecarRedis.Do("HMSET", fmt.Sprintf("song:%d", songID), "ID", songID, "CreatedAt", formattedCreatedAt, "UpdatedAt", formattedUpdatedAt, "DeletedAt", nil, "Title", song.Title, "Artist", song.Artist, "MusicAge", song.MusicAge, "Image", song.Image, "Video", song.Video, "Album", song.Album, "Description", song.Description, "SpotifyTrackId", song.SpotifyTrackId, "UserID", song.UserID))
+				if err != nil {
+					return nil, err
+				}
+				//キャッシュのTTLを1800秒(30分)に設定
+				_, err = sr.SidecarRedis.Do("EXPIRE", fmt.Sprintf("song:%d", songID), "1800")
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				//RDSからの値取得に失敗した場合
+				log.Println("RDSからの値取得に失敗")
+				return nil, result.Error
+			}
+
 		}
+
 	}
+	return &song, nil
 }
 
 func (sr *SongRepository) Save(userEmail string, p model.Song) error {

--- a/main.go
+++ b/main.go
@@ -6,12 +6,22 @@ import (
 	"os"
 	"time"
 
+	"github.com/joho/godotenv"
+
 	"github.com/garyburd/redigo/redis"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
 func main() {
+	//+++++++
+	//ここは消した上でpushする
+	err := godotenv.Load()
+	if err != nil {
+		log.Println(".envファイルの読み込み失敗")
+	}
+	//+++++++++
+
 	//RDBに接続
 	db, err := gorm.Open("mysql", os.Getenv("mysqlConfig"))
 	if err != nil {
@@ -60,13 +70,13 @@ func main() {
 
 	//サイドカーRedis
 	// コネクションの取得
-	redis2 := pool2.Get()
-	if redis2.Err() != nil {
-		log.Println(redis2.Err())
+	sidecar_redis := pool2.Get()
+	if sidecar_redis.Err() != nil {
+		log.Println(sidecar_redis.Err())
 	} else {
 		log.Println("サイドカーのRedisに接続成功")
 	}
-	defer redis2.Close()
+	defer sidecar_redis.Close()
 
-	infrastructure.Dispatch(db, redis)
+	infrastructure.Dispatch(db, redis, sidecar_redis)
 }

--- a/main.go
+++ b/main.go
@@ -6,22 +6,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/joho/godotenv"
-
 	"github.com/garyburd/redigo/redis"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
 func main() {
-	//+++++++
-	//ここは消した上でpushする
-	err := godotenv.Load()
-	if err != nil {
-		log.Println(".envファイルの読み込み失敗")
-	}
-	//+++++++++
-
 	//RDBに接続
 	db, err := gorm.Open("mysql", os.Getenv("mysqlConfig"))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -68,5 +68,8 @@ func main() {
 	}
 	defer sidecar_redis.Close()
 
+	//予めtime.Localにタイムゾーンの設定情報を入れておく
+	time.Local = time.FixedZone("Local", 9*60*60)
+
 	infrastructure.Dispatch(db, redis, sidecar_redis)
 }


### PR DESCRIPTION
**概要**

- issue#137 ( https://github.com/kt-321/golang-songs/compare/feature/golang%23134...feature/golang%23137 ) にて準備したECSのサイドカーコンテナのRedisを用いて多層キャッシュ構造を実装。

- サイドカーコンテナのRedisへとキャッシュを取りに行き、存在しない場合にはリモートのRedisへとキャッシュを取りに行き、そこにも存在しない場合にはRDSへとデータを取りに行くという形。

- サイドカーコンテナのRedis・リモートのRedis・RDSにおいて、曲のIDで情報を取得した場合（値が存在する場合）、データに差異が生じないようにしている。

- singleflightで同時関数呼び出しを1度に抑えている。

**変更点**

infrastructureパッケージにて、
- 関数Dispatchの引数にSidecarRedisを追加。

interfacesパッケージにて、
- 関数ExistsSongByID・SetSongByID・DeleteSongByIDを追加した。それぞれRedisのキャッシュの操作時に用いるもの。

- メソッドFindByID・Save・UpdateByID・DeleteByIDにおいて、上の関数を用いながらサイドカーコンテナのRedisを使用する形へと記述を変更。

- メソッドFindByIDにおいて、singleflightで同時関数呼び出しを1度に抑えている。サイドカーコンテナのRedisにもリモートのRedisにもキャッシュが存在しない場合に、RDSへの同時アクセスが多発したケースを考慮しての実装。
