### PR TITLE
構造体SongにフィールドBookmarkers追加/内部結合・メソッドFirstOrCreateを用いてクエリをシンプルなものに変更 #176

### DIFF
--- a/interfaces/bookmark_repository.go
+++ b/interfaces/bookmark_repository.go
@@ -1,9 +1,8 @@
 package interfaces
 
 import (
-	"golang-songs/model"
-
 	"github.com/jinzhu/gorm"
+	"golang-songs/model"
 )
 
 type BookmarkRepository struct {
@@ -12,27 +11,26 @@ type BookmarkRepository struct {
 
 // 曲をお気に入り登録.
 func (br *BookmarkRepository) Bookmark(userEmail string, songID int) error {
+	// リクエストユーザーを取得.
 	var user model.User
 	if err := br.DB.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
 		return err
 	}
 
+	// お気に入り登録する対象の曲を取得.
 	var song model.Song
 	if err := br.DB.Where("id = ?", songID).Find(&song).Error; gorm.IsRecordNotFoundError(err) {
 		return err
 	}
 
-	if err := br.DB.Create(&model.Bookmark{
-		UserID: user.ID,
-		SongID: song.ID}).Error; err != nil {
-		return err
-	}
-
-	if err := br.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
-		return err
-	}
-
-	if err := br.DB.Model(&user).Association("Bookmarkings").Append(&song).Error; err != nil {
+	// deleted_atがnullであるbookmarksレコードがある時はレコード追加せず、該当レコードがない時はレコード追加する.
+	if err := br.DB.
+		Where("user_id = ?", user.ID).
+		Where("song_id = ?", song.ID).
+		FirstOrCreate(&model.Bookmark{
+			UserID: user.ID,
+			SongID: song.ID}).
+		Error; err != nil {
 		return err
 	}
 
@@ -41,22 +39,19 @@ func (br *BookmarkRepository) Bookmark(userEmail string, songID int) error {
 
 // 曲をお気に入り登録から解除.
 func (br *BookmarkRepository) RemoveBookmark(userEmail string, songID int) error {
-	var user model.User
-	if err := br.DB.Where("email = ?", userEmail).Find(&user).Error; gorm.IsRecordNotFoundError(err) {
+	var bookmark model.Bookmark
+
+	// bookmarksテーブルをusersテーブルやsongsテーブルと内部結合して、該当するレコードを取得する.
+	if err := br.DB.Table("bookmarks").
+		Where("bookmarks.deleted_at is null").
+		Joins("INNER JOIN users ON users.id = bookmarks.user_id AND users.email = ? AND users.deleted_at is null", userEmail).
+		Joins("INNER JOIN songs ON songs.id = bookmarks.song_id AND songs.id = ? AND songs.deleted_at is null", songID).
+		Scan(&bookmark).Error; gorm.IsRecordNotFoundError(err) {
 		return err
 	}
 
-	var song model.Song
-
-	if err := br.DB.Where("id = ?", songID).Find(&song).Error; gorm.IsRecordNotFoundError(err) {
-		return err
-	}
-
-	if err := br.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
-		return err
-	}
-
-	if err := br.DB.Model(&user).Association("Bookmarkings").Delete(&song).Error; err != nil {
+	// bookmarksレコードを論理削除.
+	if err := br.DB.Delete(&bookmark).Error; err != nil {
 		return err
 	}
 

--- a/interfaces/song_repository.go
+++ b/interfaces/song_repository.go
@@ -262,6 +262,10 @@ func (sr *SongRepository) FindByID(songID int) (*model.Song, error) {
 		return nil, errors.New("型変換に失敗")
 	}
 
+	if err := sr.DB.Preload("Bookmarkers", "bookmarks.deleted_at is null").Find(&responseSong).Error; err != nil {
+		return nil, err
+	}
+
 	return &responseSong, nil
 }
 

--- a/interfaces/user_repository.go
+++ b/interfaces/user_repository.go
@@ -25,23 +25,7 @@ func (ur *UserRepository) GetUser(userEmail string) (*model.User, error) {
 		return nil, err
 	}
 
-	var bookmarkings []model.Song
-
-	if err := ur.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
-		return nil, err
-	}
-
-	if err := ur.DB.Model(&user).Related(&bookmarkings, "Bookmarikings").Error; err != nil {
-		return nil, err
-	}
-
-	var followings []model.User
-
-	if err := ur.DB.Preload("Followings").Find(&user).Error; err != nil {
-		return nil, err
-	}
-
-	if err := ur.DB.Model(&user).Related(&followings, "Followings").Error; err != nil {
+	if err := ur.DB.Preload("Bookmarkings", "bookmarks.deleted_at is null").Preload("Followings", "user_follows.deleted_at is null").Find(&user).Error; err != nil {
 		return nil, err
 	}
 
@@ -55,23 +39,7 @@ func (ur *UserRepository) FindByID(userID int) (*model.User, error) {
 		return nil, err
 	}
 
-	var bookmarkings []model.Song
-
-	if err := ur.DB.Preload("Bookmarkings").Find(&user).Error; err != nil {
-		return nil, err
-	}
-
-	if err := ur.DB.Model(&user).Related(&bookmarkings, "Bookmarikings").Error; err != nil {
-		return nil, err
-	}
-
-	var followings []model.User
-
-	if err := ur.DB.Preload("Followings").Find(&user).Error; err != nil {
-		return nil, err
-	}
-
-	if err := ur.DB.Model(&user).Related(&followings, "Followings").Error; err != nil {
+	if err := ur.DB.Preload("Bookmarkings", "bookmarks.deleted_at is null").Preload("Followings", "user_follows.deleted_at is null").Find(&user).Error; err != nil {
 		return nil, err
 	}
 

--- a/model/song.go
+++ b/model/song.go
@@ -18,4 +18,5 @@ type Song struct {
 	Description    string     `json:"description"`
 	SpotifyTrackId string     `json:"spotifyTrackId"`
 	UserID         uint       `json:"userId"`
+	Bookmarkers    []*User    `json:"bookmarkers" gorm:"many2many:bookmarks;""`
 }


### PR DESCRIPTION
- 構造体SongにフィールドBookmarkers追加。テーブルsongsはusersと多対多の関係

- UserRepositoryのメソッドGetUserおよびFindByIDにおいてPreloadの記述をまとめて簡潔なものにした。

- SongRepositoryのメソッドFindByIDにおいてPreloadを用いてBookmarkersの値を取得する記述を追加。

- メソッドBookmark/RemoveBookmarkおよびFollow/UnfollowにおいてFirstOrCreateや内部結合を用いることでクエリを叩く回数を減らした。
